### PR TITLE
Integration sirenopt buoydata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 *.vscode/
 *Manifest*
 *.ipynb_checkpoints/
+# Generated plots and logs
+figs/*
+!figs/.gitignore
+*.pdf
+*.png
+*.out
+*.log

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,9 @@ makedocs(
         assets = String["assets/citations.css"]),
     pages = [
         "Home" => "index.md",
-        "API" => "api.md"
+        "Quick Start" => "quickstart.md",
+        "Theory" => "theory.md",
+        "API" => "api.md",
     ],
     plugins = [bib]
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(
         "Home" => "index.md",
         "Quick Start" => "quickstart.md",
         "Theory" => "theory.md",
-        "API" => "api.md",
+        "API" => "api.md"
     ],
     plugins = [bib]
 )

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,0 +1,17 @@
+# Quick Start
+
+`BuoyData.NDBC` is the main entry point for NOAA National Data Buoy Center data.
+It can discover available records, request historical wave spectra, and read cached
+or local files.
+
+```julia
+import BuoyData: NDBC
+
+all_available = NDBC.available()
+buoy_available = NDBC.available(46050)
+spectra = NDBC.request(46050, 2021, false)
+meta = NDBC.metadata(46050)
+```
+
+The returned spectral data uses `AxisArrays`, `Unitful`, and `WaveSpectra` types
+so frequency, direction, and spectral density units remain attached to the data.

--- a/docs/src/theory.md
+++ b/docs/src/theory.md
@@ -1,0 +1,16 @@
+# Theory
+
+NDBC wave records separate omnidirectional spectral density from directional
+statistics. `swden` gives the scalar spectrum `S(f)`, while `swdir`, `swdir2`,
+`swr1`, and `swr2` describe mean directions and Fourier spreading coefficients.
+When enough directional information is available, `BuoyData.NDBC` reconstructs
+unit-aware `WaveSpectra.Spectrum` objects indexed by time.
+
+For SIRENOpt-style resource coupling, BuoyData is a data-ingestion layer. It does
+not impose device assumptions. Downstream code can integrate the returned
+spectrum, compute resource metrics, or feed a wave subsystem while preserving the
+original station metadata and units.
+
+Data availability and file formats are controlled by NDBC. Downloads require
+network access, and requested files are cached under `~/.cache/JuliaOceanWaves` to
+avoid repeated external requests during iterative simulation or optimization runs.


### PR DESCRIPTION
## Summary

This PR publishes the current `BuoyData.jl` integration-branch documentation updates.

Main changes:
- expanded documentation relevant to SIREN package integration
- clarified package purpose and expected usage within the broader resource-data workflow

## Why

`BuoyData.jl` is part of the external data/resource context used by the SIREN stack. There were a few standard pages not included.

## Notes

- This PR is documentation-oriented.
- No attempt was made here to fold in later hydro-model coupling work; that remains a separate effort.
